### PR TITLE
Eliminate Ubuntu 24.04 environment in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
     strategy:
       fail-fast: ${{ github.event_name == 'merge_group' }}
       matrix:
-        environment: [ubuntu-latest, ubuntu-24.04, macos-latest]
+        environment: [ubuntu-latest, macos-latest]
 
     runs-on: ${{ matrix.environment }}
 


### PR DESCRIPTION
This is what `ubuntu-latest` now defaults to. So the additional environment is unnecessary.